### PR TITLE
Add support for other architectures

### DIFF
--- a/Test/test.project
+++ b/Test/test.project
@@ -29,9 +29,12 @@ EXEDIR = $R/obj/bin
 	!endif
 
 	LIBC      = shared
-	OPTIONS   = -msse2									# enable SSE instructions
-	OPTIONS   += -fno-strict-aliasing					# required for our uint_cast()-based FP hacks
+
+	OPTIONS   = -fno-strict-aliasing					# required for our uint_cast()-based FP hacks
 	OPTIONS   += -fno-stack-protector					# this will remove GLIBC_2.4 dependency
+	!if "$ARCH" eq "x86_64"
+		OPTIONS   += -msse2								# enable SSE instructions
+	!endif
 !endif
 
 TEST_FILES    = Test/test.cpp

--- a/build.sh
+++ b/build.sh
@@ -3,26 +3,32 @@
 # Command line argument: test specific platform. Special case: when "win" specified, Win32 and Win64 will be used.
 PLATFORM=$1
 TYPE=$2
+ARCH=$3
 
 if [ -z "$PLATFORM" ]; then
 	PLATFORM="vc-win32"
 	[ "$OSTYPE" == "linux-gnu" ] || [ "$OSTYPE" == "linux" ] && PLATFORM="linux"
 fi
 
+if [ -z "$ARCH" ]; then
+	ARCH="$HOSTTYPE"
+fi
+
 export vc_ver=latest
 
-# Build <platform> <type>
+# Build <platform> <type> <arch>
 function Build()
 {
 	local opt_platform=$1
 	local opt_type=$2
+	local opt_arch=$3
 
 	echo "---- Making $2 target for $opt_platform ----"
 
 	# make a directory for obj files and makefiles, and generate a makefile
 	[ -d "obj" ] || mkdir obj
 	makefile="obj/makefile-$opt_type-$opt_platform"
-	Tools/genmake Test/test.project TARGET=$opt_platform TYPE=$opt_type > $makefile
+	Tools/genmake Test/test.project TARGET=$opt_platform TYPE=$opt_type ARCH=$opt_arch > $makefile
 
 	# build
 	case "$opt_platform" in
@@ -45,17 +51,21 @@ function Build()
 	esac
 }
 
-# BuildAll <platform>
+# BuildAll <platform> <arch>
 function BuildAll()
 {
 	local opt_platform=$1
+	local opt_arch=$2
+
 	if [ "$TYPE" ]; then
-		Build $opt_platform $TYPE
+		Build $opt_platform $TYPE $opt_arch
 	else
-		Build $opt_platform "C"
-		Build $opt_platform "Orig"
-		if [ "$opt_platform" != "vc-win64" ]; then
-			Build $opt_platform "Asm"			# no 64-bit assembly implementation
+		Build $opt_platform "C" $opt_arch
+		Build $opt_platform "Orig" $opt_arch
+		if [ "$opt_arch" = "x86_64" ] || [ "$opt_arch" = "i386" ]; then
+			if  [ "$opt_platform" != "vc-win64" ]; then
+				Build $opt_platform "Asm"			# no 64-bit assembly implementation
+			fi
 		fi
 	fi
 }
@@ -64,8 +74,8 @@ function BuildAll()
 
 if [ "$PLATFORM" == "win" ]; then
 	# both windows targets
-	BuildAll "vc-win32"
-	BuildAll "vc-win64"
+	BuildAll "vc-win32" $ARCH
+	BuildAll "vc-win64" $ARCH
 else
-	BuildAll $PLATFORM
+	BuildAll $PLATFORM $ARCH
 fi

--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,10 @@ if [ "$OSTYPE" == "linux-gnu" ] || [ "$OSTYPE" == "linux" ]; then
 	nong=1
 fi
 
+if [ "$HOSTTYPE" != "x86_64" ] && [ "$HOSTTYPE" != "i386" ]; then
+    noasm=1
+fi
+
 for arg in "$@"; do		# using quoted $@ will allow to correctly separate arguments like [ --path="some string with spaces" -debug ]
 #	echo "ARG=$arg"
 	case $arg in


### PR DESCRIPTION
Hi, I tried to use the test scripts on a Power processor, but I found out that some things were hardcoded (e.g. use of -msse2 flag). This PR increments the scripts to lift that limitation and enable using `build.sh` and `test.sh` for other archs besides x86.

Tested on Linux on x86_64 and powerpc64le.